### PR TITLE
Improve union of static and options-defined routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,5 @@ function routesUnion (staticRoutes, optionsRoutes) {
 
 // Make sure a passed route is an object
 function ensureRouteIsObject (route) {
-  if (typeof route === 'object') return route
-  return { url: route }
+  return typeof route === 'object' ? route : { url: route }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,15 @@ function promisifyRoute (fn) {
 
 // Join static and options-defined routes into single array
 function routesUnion (staticRoutes, optionsRoutes) {
-  staticRoutes = staticRoutes.map(route => ({ url: route }))
+  // Make sure any routes passed as strings are converted to objects with url properties
+  staticRoutes = staticRoutes.map(ensureRouteIsObject)
+  optionsRoutes = optionsRoutes.map(ensureRouteIsObject)
   // add static routes to options routes, discarding any defined in options
   return unionBy(optionsRoutes, staticRoutes, 'url')
+}
+
+// Make sure a passed route is an object
+function ensureRouteIsObject (route) {
+  if (typeof route === 'object') return route
+  return { url: route }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { Minimatch } = require('minimatch')
 const sm = require('sitemap')
 const isHTTPS = require('is-https')
-const { union, uniq } = require('lodash')
+const { unionBy, uniq } = require('lodash')
 const path = require('path')
 const fs = require('fs-extra')
 const AsyncCache = require('async-cache')
@@ -101,7 +101,7 @@ function createCache (staticRoutes, options) {
     maxAge: options.cacheTime,
     load (_, callback) {
       promisifyRoute(options.routes)
-        .then(routes => union(staticRoutes, routes))
+        .then(routes => routesUnion(staticRoutes, routes))
         .then(routes => {
           callback(null, routes)
         })
@@ -158,4 +158,11 @@ function promisifyRoute (fn) {
     promise = Promise.resolve(promise)
   }
   return promise
+}
+
+// Join static and options-defined routes into single array
+function routesUnion (staticRoutes, optionsRoutes) {
+  staticRoutes = staticRoutes.map(route => ({ url: route }))
+  // add static routes to options routes, discarding any defined in options
+  return unionBy(optionsRoutes, staticRoutes, 'url')
 }


### PR DESCRIPTION
As mentioned in #15, the current use of `lodash.union()` to combine static routes with routes set in the module’s options can lead to url duplication in the sitemap.

This pull request adds a function that:
- Ensures both `staticRoutes` and `routes` are arrays of objects with `url` properties
- Uses `lodash.unionBy()` instead of `lodash.union()` to compare by `url` property
- Prefers routes set in `options.routes` to static routes

One alternative option for consideration:
- Using `unionBy()`, we discard a static route entirely if its `url` matches a route set in the options. For now, this doesn’t matter because `staticRoutes` is always an array of strings, but if in the future some additional defaults were generated for static routes these would also be discarded. Using `lodash.merge({}, staticRoutes, routes)` instead would allow the `routes` option to _extend_ rather than override `staticRoutes`.
