### PR TITLE
Updated trailing slash filter code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ Examples:
 {
   sitemap: {
     filter ({ routes }) {
-      return routes.map(route => route.url = `${route.url}/`)
+      return routes.map(route => {
+        route.url = `${route.url}/`
+        return route
+      })
     }
   }
 }


### PR DESCRIPTION
The code example in the documentation to add a trailing slash to each route by using a `filter`, throws away all data except for the URL itself.
If you have set `defaults` (e.g. `lastmod`), these are thrown away because of the way the function in the code example is written.
This PR fixes that issue, that is both trailing slashes (by using a `filter`) and `defaults` can be used when following the documentation.