### PR TITLE
feat: custom http response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,27 @@ Add a trailing slash to each route URL (eg. `/page/1` => `/page/1/`)
 
 > **notice:** To avoid [duplicate content](https://support.google.com/webmasters/answer/66359) detection from crawlers, you have to configure an HTTP 301 redirect between the 2 URLs (see [redirect-module](https://github.com/nuxt-community/redirect-module) or [nuxt-trailingslash-module](https://github.com/WilliamDASILVA/nuxt-trailingslash-module)).
 
+### `headers` (optional) - object
+### `gzHeaders` (optional) - object
+
+- Default: `undefined`
+
+The object that contains list of custhom http response headers.
+
+```js
+// nuxt.config.js
+
+{
+  sitemap: {
+    // ...
+    headers: {
+      'Cache-Control': 'max-age=1800, s-maxage=1200, public',
+    }
+    // ...
+  }
+}
+```
+
 ### `defaults` (optional) - object
 
 - Default: `{}`

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -69,6 +69,11 @@ function registerSitemap(options, globalCache, nuxtInstance) {
           // Send http response
           res.setHeader('Content-Type', 'application/x-gzip')
           res.setHeader('Content-Encoding', 'gzip')
+          if (options.gzHeaders) {
+            for (const [headerName, headerValue] of Object.entries(options.gzHeaders)) {
+              res.setHeader(headerName, headerValue)
+            }
+          }
           res.end(gzip)
         } catch (err) {
           /* istanbul ignore next */
@@ -93,6 +98,11 @@ function registerSitemap(options, globalCache, nuxtInstance) {
         const xml = await createSitemap(options, routes, base, req).toXML()
         // Send http response
         res.setHeader('Content-Type', 'application/xml')
+        if (options.headers) {
+          for (const [headerName, headerValue] of Object.entries(options.headers)) {
+            res.setHeader(headerName, headerValue)
+          }
+        }
         res.end(xml)
       } catch (err) {
         /* istanbul ignore next */

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -114,7 +114,10 @@ describe('sitemap - advanced configuration', () => {
           xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
           xslUrl: 'sitemap.xsl',
           gzip: false,
-          cacheTime: 0
+          cacheTime: 0,
+          headers: {
+            'Cache-Control': 'max-age=0, s-maxage=0, public'
+          }
         }
       })
     })
@@ -176,7 +179,10 @@ describe('sitemap - advanced configuration', () => {
       nuxt = await startServer({
         ...config,
         sitemap: {
-          gzip: true
+          gzip: true,
+          gzHeaders: {
+            'Cache-Control': 'max-age=0, s-maxage=0, public'
+          }
         }
       })
 


### PR DESCRIPTION
This commit adds ability to set custom http response header. I've needed this functionality to set nginx reverse proxy cahe headers.