### PR TITLE
fix: Cannot read property 'filter' of null on Zeit

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -23,7 +23,7 @@ module.exports = async function module(moduleOptions) {
     ? path.resolve(nuxtInstance.options.buildDir, path.join('dist', 'sitemap-routes.json'))
     : null
   const staticRoutes = fs.readJsonSync(jsonStaticRoutesPath, { throws: false })
-  const globalCache = { staticRoutes }
+  const globalCache = { staticRoutes: staticRoutes || [] }
 
   // Init static routes
   nuxtInstance.extendRoutes((routes) => {


### PR DESCRIPTION
`routes` is null when using @nuxtjs/now-builder on Zeit. This fix sets an empty array when the variable null.