### PR TITLE
feat: Trigger done hook after generating sitemaps

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -40,7 +40,8 @@ module.exports = async function module(moduleOptions) {
   // On "generate" mode, generate static files for each sitemap or sitemapindex
   nuxtInstance.nuxt.hook('generate:done', async () => {
     logger.info('Generating sitemaps')
-    await Promise.all(options.map((options) => generateSitemaps(options, globalCache, nuxtInstance)))
+    await Promise.all(options.map((options) => generateSitemaps(options, globalCache, nuxtInstance))).
+      then(() => nuxtInstance.nuxt.callHook('generateSitemaps:done', this))
   })
 
   // On "ssr" mode, register middlewares for each sitemap or sitemapindex


### PR DESCRIPTION
Without this hook I don't know when the build process is finished. I need this to stop a service thats running in the background while generating. 
```
hooks: {
    generateSitemaps: {
      done: () => {}
    }
}
```