### PR TITLE
Make translated static routes sitemaps

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -25,7 +25,7 @@ module.exports = async function module(moduleOptions) {
   const staticRoutes = fs.readJsonSync(jsonStaticRoutesPath, { throws: false })
   const globalCache = { staticRoutes }
 
-  // Wait for the build modules 
+  // Wait for the build modules
   this.nuxt.hook('build:before', () => {
     // Init static routes
     nuxtInstance.extendRoutes((routes) => {

--- a/lib/module.js
+++ b/lib/module.js
@@ -25,16 +25,19 @@ module.exports = async function module(moduleOptions) {
   const staticRoutes = fs.readJsonSync(jsonStaticRoutesPath, { throws: false })
   const globalCache = { staticRoutes }
 
-  // Init static routes
-  nuxtInstance.extendRoutes((routes) => {
-    // Create a cache for static routes
-    globalCache.staticRoutes = getStaticRoutes(routes)
+  // Wait for the build modules 
+  this.nuxt.hook('build:before', () => {
+    // Init static routes
+    nuxtInstance.extendRoutes((routes) => {
+      // Create a cache for static routes
+      globalCache.staticRoutes = getStaticRoutes(routes)
 
-    // On run cmd "build"
-    if (!nuxtInstance.options.dev) {
-      // Save static routes
-      fs.outputJsonSync(jsonStaticRoutesPath, globalCache.staticRoutes)
-    }
+      // On run cmd "build"
+      if (!nuxtInstance.options.dev) {
+        // Save static routes
+        fs.outputJsonSync(jsonStaticRoutesPath, globalCache.staticRoutes)
+      }
+    })
   })
 
   // On "generate" mode, generate static files for each sitemap or sitemapindex


### PR DESCRIPTION
Waiting for the await import of the nuxt-i18n module initial extendRoutes call: https://github.com/nuxt-community/i18n-module/blob/22c38d7c122673e1c47066fe42e4ad1d81039b4b/src/core/hooks.js#L45