### PR TITLE
fix: return value of getHostname

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -163,11 +163,10 @@ function getHostname(options, req, base) {
   if (!options.hostname && !req) {
     logger.fatal('The `hostname` option is mandatory in your config on `spa` or `generate` build mode', options)
   }
-  return (
-    options.hostname ||
-    (req && `${isHTTPS(req) ? 'https' : 'http'}://${req.headers.host}${base}`) ||
-    `http://${hostname()}${base}`
-  )
+  return new URL(
+    base,
+    options.hostname || (req && `${isHTTPS(req) ? 'https' : 'http'}://${req.headers.host}`) || `http://${hostname()}`
+  ).href
 }
 
 module.exports = { createSitemap, createSitemapIndex }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -163,9 +163,10 @@ function getHostname(options, req, base) {
   if (!options.hostname && !req) {
     logger.fatal('The `hostname` option is mandatory in your config on `spa` or `generate` build mode', options)
   }
-  return join(
-    options.hostname || (req && `${isHTTPS(req) ? 'https' : 'http'}://${req.headers.host}`) || `http://${hostname()}`,
-    base
+  return (
+    options.hostname ||
+    (req && `${isHTTPS(req) ? 'https' : 'http'}://${req.headers.host}${base}`) ||
+    `http://${hostname()}${base}`
   )
 }
 


### PR DESCRIPTION
Return value of getHostname is incorrect when the hostname
option is omitted. Due to using path.join for appending the
base argument the return value will be missing one slash
after the protocol. Example `http:/localhost:3000`.

Replaced path.join with template literals appending the
base argument.