### PR TITLE
refactor: use nuxt everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://img.shields.io/codecov/c/github/nuxt-community/sitemap-module?style=flat-square)](https://codecov.io/gh/nuxt-community/sitemap-module)
 [![License](https://img.shields.io/npm/l/@nuxtjs/sitemap?style=flat-square)](http://standardjs.com)
 
-> Automatically generate or serve dynamic [sitemap.xml](https://www.sitemaps.org/protocol.html) for Nuxt.js projects!
+> Automatically generate or serve dynamic [sitemap.xml](https://www.sitemaps.org/protocol.html) for Nuxt projects!
 
 [📖 **Release Notes**](./CHANGELOG.md)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nuxtjs/sitemap",
   "version": "2.4.0",
-  "description": "Automatically generate or serve dynamic sitemap.xml for Nuxt.js projects",
+  "description": "Automatically generate or serve dynamic sitemap.xml for Nuxt projects",
   "keywords": [
     "nuxt",
     "nuxt.js",


### PR DESCRIPTION
✏️  Use `Nuxt` instead of `Nuxt.js`

(related to https://github.com/nuxt/nuxt.js/pull/8210)