### PR TITLE
docs: add Vercel guide

### DIFF
--- a/docs/content/en/guide/Deploy
+++ b/docs/content/en/guide/Deploy
@@ -1,0 +1,27 @@
+---
+title: Deploy
+description: 'Things you need to know for deployment'
+position: 4
+category: Guide
+---
+
+## Deploy SSR with Vercel
+
+When deploying Nuxt SSR with Vercel you need to add `.nuxt/dist/sitemap-routes.json` file as `serverFiles`. See the example below:
+
+```js[vercel.json]
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "nuxt.config.js",
+      "use": "@nuxtjs/vercel-builder",
+      "config": {
+        "serverFiles": [
+          ".nuxt/dist/sitemap-routes.json"
+        ]
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
I was looking into a solution for the error on Vercel and found the solution in the closed issues back in 2020.
https://github.com/nuxt-community/sitemap-module/issues/106

I thought might be a good idea to add it to docs. I thought maybe to add a Deploy page to the guides section. 
