### PR TITLE
feat: Support option to access req.headers.host in dynamic routes function

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -13,16 +13,23 @@ const unionBy = require('lodash.unionby')
 function createRoutesCache(globalCache, options) {
   const cache = new AsyncCache({
     maxAge: options.cacheTime,
-    async load(_, callback) {
+    async load(key, callback) {
       try {
-        let routes = await promisifyRoute(options.routes)
+        let routes;
+        if (options.dynamicHost) {
+          // strip away 'routes--' string to parse host
+          const host = key.replace('routes--', '')
+          // make host param available in options route function
+          routes = await options.routes(host)
+        } else {
+          routes = await promisifyRoute(options.routes)
+        }
         routes = joinRoutes(globalCache.staticRoutes ? globalCache.staticRoutes() : [], routes)
         callback(null, routes)
       } catch (err) {
         /* istanbul ignore next */
         callback(err)
       }
-    },
   })
   cache.get = promisify(cache.get)
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -30,6 +30,7 @@ function createRoutesCache(globalCache, options) {
         /* istanbul ignore next */
         callback(err)
       }
+    }
   })
   cache.get = promisify(cache.get)
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -68,7 +68,7 @@ function registerSitemap(options, globalCache, nuxtInstance, depth = 0) {
       async handler(req, res, next) {
         try {
           // Init sitemap
-          const routes = await cache.routes.get('routes')
+          const routes = await cache.routes.get('routes--' + req.headers.host)
           const gzip = await createSitemap(options, routes, base, req).toGzip()
           // Check cache headers
           if (validHttpCache(gzip, options.etag, req, res)) {
@@ -96,7 +96,7 @@ function registerSitemap(options, globalCache, nuxtInstance, depth = 0) {
     async handler(req, res, next) {
       try {
         // Init sitemap
-        const routes = await cache.routes.get('routes')
+        const routes = await cache.routes.get('routes--' + req.headers.host)
         const xml = await createSitemap(options, routes, base, req).toXML()
         // Check cache headers
         if (validHttpCache(xml, options.etag, req, res)) {


### PR DESCRIPTION
This PR allows you to access req.headers.host when dynamically generating routes as requested in #217 #216 #215 #11

✨ Helpful for multi-tenant projects where the subdomain is needed to identify a user [user].maindomain.com

In order to use it the **`dynamicHost`** option must be enabled. Then the `host` parameter is available to be used in the routes function.

See example:

```
sitemap: {
    dynamicHost: true,
    routes: async (host) => {
      const subdomain = host.split('.')[0]
      const res = axios.get('https://myapi.com/getAllPages?user=' + subdomain)
      return res.data
     }
}
```

––––––––––––-

This is my first PR ever on Github and the solution is quite hacky – so please take it with a grain of salt and see it more as an inspiration on how this functionality could be achieved.