### PR TITLE
Update cache.js to make option to specify route name in dynamic routes for grouping to hreflang links

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -93,12 +93,11 @@ function ensureIsValidRoute(route) {
   if (typeof route === 'object') {
     const routeToReturn = {}
     if (route.route) {
-      routeToReturn.url = route.route
+      routeToReturn.url = String(route.route)
     }
     if(route.name) {
       routeToReturn.name = route.name
     }
-    routeToReturn.url = String(routeToReturn.url)
 
     return routeToReturn;
   }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -85,7 +85,6 @@ function joinRoutes(staticRoutes, dynamicRoutes) {
  * @param   {Object | string} route Route Object or Payload Object or String value
  * @returns {Object} A valid route object
  */
-
 function ensureIsValidRoute(route) {
   if (typeof route === 'string') {
     return { url: route }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -93,6 +93,10 @@ function ensureIsValidRoute(route) {
     if(route.name) {
       routeToReturn.name = route.name
     }
+
+    if(route.lastmod) {
+      routeToReturn.lastmod = route.lastmod
+    }
   } else {
     routeToReturn = { url: route };
   }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -85,11 +85,25 @@ function joinRoutes(staticRoutes, dynamicRoutes) {
  * @param   {Object | string} route Route Object or Payload Object or String value
  * @returns {Object} A valid route object
  */
+
 function ensureIsValidRoute(route) {
-  route = typeof route === 'object' ? (route.route ? { url: route.route } : route) : { url: route }
-  // force as string
-  route.url = String(route.url)
-  return route
+  if (typeof route === 'string') {
+    return { url: route }
+  }
+  if (typeof route === 'object') {
+    const routeToReturn = {}
+    if (route.route) {
+      routeToReturn.url = route.route
+    }
+    if(route.name) {
+      routeToReturn.name = route.name
+    }
+    routeToReturn.url = String(routeToReturn.url)
+
+    return routeToReturn;
+  }
+
+  return route;
 }
 
 module.exports = { createRoutesCache }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -86,22 +86,20 @@ function joinRoutes(staticRoutes, dynamicRoutes) {
  * @returns {Object} A valid route object
  */
 function ensureIsValidRoute(route) {
-  if (typeof route === 'string') {
-    return { url: route }
-  }
+  let routeToReturn = null;
   if (typeof route === 'object') {
-    const routeToReturn = {}
-    if (route.route) {
-      routeToReturn.url = String(route.route)
-    }
+    routeToReturn = route.route ? { url: route.route } : route
+
     if(route.name) {
       routeToReturn.name = route.name
     }
-
-    return routeToReturn;
+  } else {
+    routeToReturn = { url: route };
   }
 
-  return route;
+  routeToReturn.url = String(routeToReturn.url);
+
+  return routeToReturn;
 }
 
 module.exports = { createRoutesCache }


### PR DESCRIPTION
sitemap groups links to <url><xhtml:link></url> format based on route names. 
when we have a list of dynamic routes, it does not have name and can't be grouped.
With this pr there will be an ability to group routes by manually giving specific names to dynamic routes.
basically it checks whether route has "name" parameter, and adds that to an object along with "url" parameter.