### PR TITLE
docs(pt): add the portuguese documentation of the website

### DIFF
--- a/docs/content/pt/guide/configuration.md
+++ b/docs/content/pt/guide/configuration.md
@@ -1,0 +1,74 @@
+---
+title: Configuração
+description: 'Adicionar uma configuração personalizada para o módulo sitemap'
+position: 3
+category: Guide
+---
+
+Adicionar uma configuração personalizada com a propriedade `sitemap`:
+
+```js[nuxt.config.js]
+{
+  modules: [
+    '@nuxtjs/sitemap'
+  ],
+  sitemap: {
+    // opções
+  },
+}
+```
+
+O parâmetro da opção do módulo pode ser:
+
+### `Object`
+
+Um item único de [sitemap](/usage/sitemap) ou [índice de sitemap](#sitemap-index-options):
+
+```js
+{
+  sitemap: {
+    // ...
+  },
+}
+```
+
+### `Array`
+
+Uma lista de [sitemap](#sitemap-options) ou itens de [índice de sitemap](#sitemap-index-options) items:
+
+```js
+{
+  sitemap: [
+    {
+      // ...
+    },
+    {
+      // ...
+    },
+  ],
+}
+```
+
+### `Function`
+
+Uma função que retorna uma configuração de sitemap válida:
+
+```js
+{
+  sitemap: function () {
+    return {
+      // ...
+    }
+  },
+}
+```
+
+### `Boolean`
+
+Você pode desativar o módulo sitemap com um valor booleano `false`:
+
+```js
+{
+  sitemap: false
+}
+```

--- a/docs/content/pt/guide/setup.md
+++ b/docs/content/pt/guide/setup.md
@@ -1,0 +1,43 @@
+---
+title: Configurar
+description: 'Configurar o módulo sitemap para a Nuxt'
+position: 2
+category: Guide
+---
+
+## Instalação
+
+Adicionar a dependência `@nuxtjs/sitemap` ao seu projeto:
+
+<code-group>
+  <code-block label="Yarn" active>
+
+  ```bash
+  yarn add @nuxtjs/sitemap
+  ```
+
+  </code-block>
+  <code-block label="NPM">
+
+  ```bash
+  npm install @nuxtjs/sitemap
+  ```
+
+  </code-block>
+</code-group>
+
+## Configurar
+
+Adicionar `@nuxtjs/sitemap` para a secção `modules` do seu ficheiro `nuxt.config.js`:
+
+```js[nuxt.config.js]
+{
+  modules: [
+    '@nuxtjs/sitemap'
+  ],
+}
+```
+
+> **Atenção:**
+> Se você usa outros módulos (exemplo, `nuxt-i18n`), sempre declare o módulo sitemap no final do arranjo
+> exemplo, `modules: ['nuxt-i18n', '@nuxtjs/sitemap']`

--- a/docs/content/pt/index.md
+++ b/docs/content/pt/index.md
@@ -1,0 +1,35 @@
+---
+title: Introdução
+description: 'Módulo Sitemap para Nuxt'
+position: 1
+category: ''
+features:
+  - Módulo baseado no fantástico pacote sitemap.js ❤️
+  - Cria o sitemap ou índice de sitemap
+  - Adiciona automaticamente as rotas estáticas para cada sitemap
+  - Suporte a rotas i18n do nuxt-i18n (versão mais recente)
+  - Funciona com todos os modos (SSR, SPA, generate)
+  - Para Nuxt 2.x e superior
+---
+
+<img src="/preview.png" class="light-img" width="1280" height="640" alt=""/>
+<img src="/preview-dark.png" class="dark-img" width="1280" height="640" alt=""/>
+
+[Módulo Sitemap de Nuxt](https://github.com/nuxt-community/sitemap-module) para [NuxtJS](https://nuxtjs.org).
+
+Gera automaticamente ou serve [sitemap.xml](https://github.com/ekalinin/sitemap.js) dinâmico para projetos Nuxt!
+
+## Funcionalidades
+
+<list :items="features"></list>
+
+## Mais recursos
+
+* [GitHub](https://github.com/nuxt-community/sitemap-module)
+* [Lançamentos](https://github.com/nuxt-community/sitemap-module/releases)
+* [Licença MIT](./LICENSE)
+
+## Colaboradores
+
+- [Nicolas Pennec](https://github.com/NicoPennec)
+- [Pooya Parsa](https://github.com/pi0)

--- a/docs/content/pt/usage/hooks.md
+++ b/docs/content/pt/usage/hooks.md
@@ -1,0 +1,15 @@
+---
+title: Gatilhos
+description: 'Gatilhos para o módulo sitemap'
+position: 7
+category: Usage
+---
+
+Os gatilhos são observadores para eventos da Nuxt. [Leia mais](https://nuxtjs.org/api/configuration-hooks)
+
+Você pode registar os gatilhos em certos eventos do ciclo de vida.
+
+| Gatilho  | Argumentos  | Quando | 
+|---|---|---|
+| sitemap:generate:before  | (nuxt, sitemapOptions) | Acionado antes da geração do sítio |
+| sitemap:generate:done  | (nuxt) | Acionado depois de terminado a geração do sitemap |

--- a/docs/content/pt/usage/sitemap-index.md
+++ b/docs/content/pt/usage/sitemap-index.md
@@ -1,0 +1,59 @@
+---
+title: Índice de sitemap
+description: 'Declarar um índice de sitemap e seus sitemaps ligados'
+position: 5
+category: Usage
+---
+
+### Configurar um índice de sitemap
+
+Para declarar um índice o sitemap e seus sitemaps ligados, use a propriedade [`sitemaps`](/usage/sitemap-options#sitemaps---array-of-object).
+
+Por padrão, o índice do sitemap é configurado para o seguinte caminho: `/Sitemap.xml`
+
+Todo item do arranjo `sitemaps` pode ser configurado com as suas próprias [opções de sitemap]/usage/sitemap-options).
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    hostname: 'https://example.com',
+    lastmod: '2017-06-30',
+    sitemaps: [
+      {
+        path: '/sitemap-foo.xml',
+        routes: ['foo/1', 'foo/2'],
+        gzip: true
+      }, {
+        path: '/folder/sitemap-bar.xml',
+        routes: ['bar/1', 'bar/2'],
+        exclude: ['/**']
+      }
+    ]
+  }
+}
+```
+
+### Configurar uma lista de sitemaps
+
+Para declarar uma lista de sitemaps, use um `array` para configurar cada sitemap com sua própria configuração.
+
+```js[nuxt.config.js]
+{
+  sitemap: [
+    {
+      path: '/sitemap-products.xml',
+      routes: [
+        // array of URL
+      ]
+    }, {
+      path: '/sitemap-news.xml',
+      routes: () => // promise or function
+    }, {
+      path: '/sitemapindex.xml',
+      sitemaps: [{
+        // array of Sitemap configuration
+      }]
+    }
+  }
+}
+```

--- a/docs/content/pt/usage/sitemap-options.md
+++ b/docs/content/pt/usage/sitemap-options.md
@@ -1,0 +1,364 @@
+---
+title: Opções de sitemap
+description: 'Módulo de opções de sitemap'
+position: 6
+category: Usage
+---
+
+### `routes` (opcional) - array | function
+
+- Valor predefinido: `[]` ou valor de [`generate.routes`](https://nuxtjs.org/api/configuration-generate#routes) do seu `nuxt.config.js`
+
+
+O parâmetro `routes` segue o mesmo caminho da [configuração]https://nuxtjs.org/api/configuration-generate#routes) do `generate`.
+
+Consulte também os exemplos de [declaração das rotas](/usage/sitemap-options#routes-declaration) abaixo.
+
+### `path` (opcional) - string
+
+- Valor predefinido: `/sitemap.xml`
+
+O caminho da URL do sitemap gerado.
+
+### `hostname` (opcional) - string
+
+- Valor predefinido:
+  1. Valor de `sitemap.hostname` do seu `nuxt.config.js`
+  2. Valor de [`build.publicPath`](https://nuxtjs.org/api/configuration-build/#publicpath) do seu `nuxt.config.js` (⚠️ **depreciado**)
+  3. [`os.hostname()`](https://nodejs.org/api/os.html#os_os_hostname) no modo **generate** ou **spa**, ou dinamicamente baseado na URL (`headers.host`) da requisição no modo **spa**.
+
+Este valor é **obrigatório** para geração do ficheiro sitemap, e você deve fornecê-lo explicitamente no modo **generate** ou **spa**.
+
+<alert type="warning">
+
+  O uso do `build.publicPath` como valor padrão está depreciado e será removido no lançamento da versão 3.0.
+  Para desativá-lo no lançamento atual, defina um valor falso (exemplo, `hostname: false`).
+
+</alert>
+
+### `cacheTime` (opcional) - number
+
+- Valor predefinido: `1000 * 60 * 15` (15 Minutos)
+
+Define com que frequência as **rotas** do sitemap devem ser atualizadas (valor em milissegundos).
+A definição de um valor negativo desativará o cache.
+
+Por favor repare que depois de cada invalidação, as `rotas` serão avaliadas novamente (consulte a secção [declaração de rotas](/usage/sitemap-options#declaração-de-rotas)).
+
+This option is only available in **ssr** mode.
+Este opção apenas está disponível no modo **ssr**.
+
+### `etag` (opcional) - object
+
+- Valor predefinido: valor de [`render.etag`](https://nuxtjs.org/api/configuration-render#etag) do seu `nuxt.config.js`
+
+Ativa o cabeçalho de cache do `etag` no sitemap (consulte documentação [etag](https://nuxtjs.org/api/configuration-render#etag) para possíveis opções).
+
+Para desativar o `etag` para o sitemap defina `etag: false`
+
+Esta opção está apenas disponível no modo **ssr**.
+
+### `exclude` (opcional) - string array
+
+- Valor predefinido: `[]`
+
+O parâmetro `exclude` é um arranjo de [padrões glob](https://github.com/isaacs/minimatch#features) para excluir rotas estáticas a partir do sitemap gerado.
+
+### `filter` (opcional) - function
+
+- Valor predefinido: `undefined`
+
+Se a opção `filter` estiver definida como função, todas as rotas serão filtradas através dela.
+
+Esta opção é útil para personalizar ou estender as funcionalidades do módulo, antes da geração do sitemap.
+
+Exemplos:
+
+```js[nuxt.config.js]
+// Filtrar as rotas por linguagem
+{
+  sitemap: {
+    filter ({ routes, options }) {
+      if (options.hostname === 'example.com') {
+        return routes.filter(route => route.locale === 'en')
+      }
+      return routes.filter(route => route.locale === 'fr')
+    }
+  }
+}
+
+// Adicionar uma barra final para cada rota
+{
+  sitemap: {
+    filter ({ routes }) {
+      return routes.map(route => {
+        route.url = `${route.url}/`
+        return route
+      })
+    }
+  }
+}
+```
+
+### `gzip` (opcional) - boolean
+
+- Valor predefinido: `false`
+
+Ativa a criação do sitemap `.xml.gz` comprimida com o gzip.
+
+### `xmlNs` (opcional) - string
+
+- Valor predefinido: `undefined`
+
+Define os nomes de espaços de XML pela sobrescrição de todos atributos predefinidos no elemento `<urlset>`.
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+  }
+}
+```
+
+### `xslUrl` (opcional) - string
+
+- Valor predefinido: `undefined`
+
+O caminho da URL do ficheiro XSL para estilizar o sitemap.
+
+### `trailingSlash` (opcional) - boolean
+
+- Valor predefinido: `false`
+
+Adiciona uma barra final para cada rota de URL (exemplo, `/page/1` => `/page/1/`)
+
+> **aviso:** para evitar deteção de [conteúdo duplicado](https://support.google.com/webmasters/answer/66359) a partir dos rastreadores, você precisa configurar um redirecionamento de código 301 de HTTP entre 2 URLs (consulte [redirect-module](https://github.com/nuxt-community/redirect-module) ou [nuxt-trailingslash-module](https://github.com/WilliamDASILVA/nuxt-trailingslash-module)).
+
+### `i18n` (opcional) - string | object
+
+- Valor predefinido: `undefined`
+
+Configura o suporte de rotas localizadas a partir do módulo **[nuxt-i18n](https://i18n.nuxtjs.org/)**.
+
+Se a opção `i18n` estiver configurada, o módulo sitemap adicionará automaticamente o local da URL padrão de cada página em um elemento `<loc>`, com entradas `<xhtml:link>` filhas listando todas variedade de idiomas/local da página incluindo a si mesma (consulte as [orientações de sitemap do Google](https://support.google.com/webmasters/answer/189077)).
+
+Exemplo:
+
+```js[nuxt.config.js]
+{
+  modules: [
+    'nuxt-i18n',
+    '@nuxtjs/sitemap'
+  ],
+  i18n: {
+    locales: ['en', 'es', 'fr'],
+    defaultLocale: 'en'
+  },
+  sitemap: {
+    hostname: 'https://example.com',
+    // notação de atalho (básico)
+    i18n: true,
+    // notação do nuxt-i18n (avançado)
+    i18n: {
+      locales: ['en', 'es', 'fr'],
+      routesNameSeparator: '___'
+    }
+  }
+}
+```
+
+```xml
+  <url>
+    <loc>https://example.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://example.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/"/>
+  </url>
+  <url>
+    <loc>https://example.com/es/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://example.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/"/>
+  </url>
+  <url>
+    <loc>https://example.com/fr/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://example.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/"/>
+  </url>
+```
+
+### `defaults` (opcional) - object
+
+- Valor predefinido: `{}`
+
+O parâmetro `defaults` define as opções padrão para todas rotas.
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    defaults: {
+      changefreq: 'daily',
+      priority: 1,
+      lastmod: new Date()
+    }
+  }
+}
+```
+
+[Consulte as opções disponíveis](https://github.com/ekalinin/sitemap.js/blob/4.1.1/README.md#sitemap-item-options)
+
+## Opções do Índice do Sitemap
+
+### `path` (opcional) - string
+
+- Valor predefinido: `/sitemapindex.xml`
+
+O caminho da URL do índice do sitemap gerado.
+
+### `hostname` (opcional) - string
+
+Defina o valor `hostname` para cada sitemap ligados ao seu índice de sitemap.
+
+### `sitemaps` - array of object
+
+- Valor predefinido: `[]`
+
+Arranjo de [configuração de sitemap](/usage/sitemap-options#routes-opcional---array--function) ligados ao índice do sitemap.
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    path: '/sitemapindex.xml',
+    hostname: 'https://example.com',
+    sitemaps: [
+      {
+        path: '/sitemap-foo.xml',
+        // ...
+      }, {
+        path: '/folder/sitemap-bar.xml',
+        // ...
+      }
+    ]
+  }
+}
+```
+
+```xml
+<!-- generated sitemapindex.xml -->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-foo.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/folder/sitemap-bar.xml</loc>
+  </sitemap>
+</sitemapindex>
+```
+
+Consulte mais [exemplos](/usage/sitemap#setup-a-sitemap acima.
+
+### `lastmod` (opcional) - string
+
+Defina o valor `lastmod` para cada sitemap ligado para o seu índice de sitemap.
+
+Além disso, o `lastmod` pode ser definido para cada sitemap ligado.
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    lastmod: "2020-01-01",
+    sitemaps: [
+      {
+        path: '/sitemap-foo.xml',
+        lastmod: "2020-01-02"
+      }, {
+        path: '/sitemap-bar.xml'
+      }
+    ]
+  }
+}
+```
+
+### `etag` (opcional) - object
+
+- Valor predefinido: valor de [`render.etag`](https://nuxtjs.org/api/configuration-render#etag) do seu `nuxt.config.js`
+
+Ativa o cabeçalho de cache `etag` no índice do sitemap (Consulte a documentação [etag](https://nuxtjs.org/api/configuration-render#etag) para possíveis opções).
+
+Para desativar o `etag` para o índice de sitemap defina o `etag: false`
+
+Esta opção está apenas disponível no modo **ssr**.
+
+### `gzip` (opcional) - boolean
+
+- Valor predefinido: `false`
+
+Ativa a criação do `.xml.gz` do índice do sitemap comprimido com gzip.
+
+### `xmlNs` (opcional) - string
+
+- Valor predefinido: `undefined`
+
+Define o nome de espaços de XML pela sobrescrição de todos atributos padrão `xmls` no elemento `<sitemapindex>`.
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
+    sitemaps: [...]
+  }
+}
+```
+
+### `xslUrl` (opcional) - string
+
+- Valor predefinido: `undefined`
+
+O caminho da URL do ficheiro XSL para estilizar o índice do sitemap.
+
+## Declaração de Rotas
+
+Por padrão, as rotas dinâmicas são ignoradas pelo módulo sitemap.
+A Nuxt não consegue fornecer este tipo de rotas complexa automaticamente.
+
+Exemplo:
+
+```
+-| pages/
+---| index.vue  --> static route
+---| about.vue  --> static route
+---| users/
+-----| _id.vue  --> dynamic route
+```
+
+Se você quiser que o módulo adicione qualquer rota com parâmetros dinâmicos, você precisa definir um arranjo de rotas dinâmicas.
+
+Por exemplo, adicionar rotas para `/users/:id` na configuração:
+
+### A partir de uma lista estática
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    routes: ['/users/1', '/users/2', '/users/3']
+  }
+}
+```
+
+### A partir de uma função que retorna uma Promessa
+
+```js[nuxt.config.js]
+const axios = require('axios')
+
+{
+  sitemap: {
+    routes: async () => {
+      const { data } = await axios.get('https://jsonplaceholder.typicode.com/users')
+      return data.map((user) => `/users/${user.username}`)
+    }
+  }
+}
+```

--- a/docs/content/pt/usage/sitemap.md
+++ b/docs/content/pt/usage/sitemap.md
@@ -1,0 +1,37 @@
+---
+title: Sitemap
+description: 'Configurar um sitemap'
+position: 4
+category: Usage
+---
+
+### Configurar um sitemap
+
+Por padrão, o sitemap é configurado para o seguinte caminho: `/sitemap.xml`
+
+Todas as rotas estáticas (exemplo, `/pages/about.vue`) são automaticamente adicionado ao sitemap, mas você pode excluir cada um deles com a propriedade [`exclude`](/usage/sitemap-options#exclude-optional---string-array)
+
+Para as rotas dinâmicas (exemplo, `/pages/_id.vue`), você precisa declará-los com a propriedade [`routes`](/usage/sitemap-options#routes-optional---array--function). Esta opção pode ser um arranjo ou uma função. Além disso, as rotas definidas em `generate.routes` serão automaticamente usados pelo sitemap.
+
+```js[nuxt.config.js]
+{
+  sitemap: {
+    hostname: 'https://example.com',
+    gzip: true,
+    exclude: [
+      '/secret',
+      '/admin/**'
+    ],
+    routes: [
+      '/page/1',
+      '/page/2',
+      {
+        url: '/page/3',
+        changefreq: 'daily',
+        priority: 1,
+        lastmod: '2017-06-30T13:30:00.000Z'
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
In this pull request, I am sending a website repository with the
`docs/content/pt` with all files already translated to Portuguese,
this is to prepare the ground to serve a Portuguese version of 
the documentation that will be updated with the update of the site.